### PR TITLE
[no-ticket] Regression Fixes

### DIFF
--- a/app/routes/scan.js
+++ b/app/routes/scan.js
@@ -24,6 +24,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             tools: _tools,
             status: Ember.$.getJSON(config.APP.api_url + config.APP.api_namespace + '/status'),
             selectUsers: _users,
+            allUsers: Ember.$.getJSON(config.APP.api_url + config.APP.api_namespace + '/users'),
             types: Ember.$.getJSON(config.APP.api_url + config.APP.api_namespace + '/types'),
             brands: Ember.$.getJSON(config.APP.api_url + config.APP.api_namespace + '/brands')
         });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -132,7 +132,6 @@ a:-webkit-any-link {
 }
 
 #screen-view {
-  overflow: scroll;
   position: relative;
   height: calc(100vh - 108px);
 	width: 100vw;


### PR DESCRIPTION
Scroll Regression: on the search page we had that issue come back where there was a double scroll. Found that I had removed `overflow: scroll` in [this commit](https://github.com/Renascentinc/retina-app/commit/8a2fcb2a842d528a456239980a5b5d4440bfd4db) but somehow it worked its way back into the code.

Transfer Regression: the transfer to dropdown was not getting populated. I had removed an api call that I thought was unecessary... my bad : /